### PR TITLE
Added ghc-modi

### DIFF
--- a/Hub/Prog.hs
+++ b/Hub/Prog.hs
@@ -41,6 +41,7 @@ data P
     | HappyP
     | HaddockP
     | GhcModP
+    | GhcModiP
     | HLintP
     | HDevToolsP
     | HaskellDocsP
@@ -63,6 +64,7 @@ p2prog p =
       AlexP              -> PROG p "alex"             TlPT
       HappyP             -> PROG p "happy"            TlPT
       GhcModP            -> PROG p "ghc-mod"          TlPT
+      GhcModiP           -> PROG p "ghc-modi"         TlPT
       HLintP             -> PROG p "hlint"            TlPT
       HDevToolsP         -> PROG p "hdevtools"        TlPT
       HaskellDocsP       -> PROG p "haskell-docs"     TlPT

--- a/Version.hs
+++ b/Version.hs
@@ -13,7 +13,7 @@ module Version
 
 
 version :: String
-version = "1.3.0"
+version = "1.3.1"
 
 
 main :: IO ()

--- a/hub.cabal
+++ b/hub.cabal
@@ -1,5 +1,5 @@
 Name:                   hub
-Version:                1.3.0
+Version:                1.3.1
 Copyright:              Chris Dornan, 2011-2013
 Maintainer:             Chris Dornan <chris@chrisdornan.com>
 Author:                 Chris Dornan <chris@chrisdornan.com>


### PR DESCRIPTION
Newest ghc-mod ships with a new executable called "ghc-modi" as well as the standard one.

Ti patch allows hub to hook into it correctly.

@cdornan I have bumped the hub version both in the manifest and in Version.hs, please shout if this is not ideal.

Alfredo
